### PR TITLE
fix: remove link to appStyles

### DIFF
--- a/app/root.jsx
+++ b/app/root.jsx
@@ -41,7 +41,6 @@ export const shouldRevalidate = ({
 
 export function links() {
   return [
-    { rel: 'stylesheet', href: appStyles },
     {
       rel: 'preconnect',
       href: 'https://cdn.shopify.com',


### PR DESCRIPTION
Due to our custom require function, importing from a CSS file returns an object instead of a URL. This causes 404 errors when trying to create a `<link>` element with this object.
<img width="387" alt="image" src="https://github.com/concrete-utopia/hydrogen-editions-24/assets/7003853/8c662d0f-afea-421a-889d-b09662d397d8">
<img width="627" alt="image" src="https://github.com/concrete-utopia/hydrogen-editions-24/assets/7003853/e7f78819-cf3b-4072-bf8c-24eb200b8cca">

The fix is to temporarily remove this line, since it doesn't do anything right now (the CSS is already present by the import)