### PR TITLE
Put back early returns to section components.

### DIFF
--- a/app/routes/products.$handle/route.jsx
+++ b/app/routes/products.$handle/route.jsx
@@ -156,7 +156,7 @@ export default function Product() {
       <Marquee />
       <HighlightDetails />
       <HighlightSolution />
-      <Reviews />
+      {customerReviews != null ? <Reviews /> : null}
       <Recommended />
       <Spotlight />
     </Column>

--- a/app/routes/products.$handle/route.jsx
+++ b/app/routes/products.$handle/route.jsx
@@ -156,7 +156,7 @@ export default function Product() {
       <Marquee />
       <HighlightDetails />
       <HighlightSolution />
-      {customerReviews != null ? <Reviews /> : null}
+      <Reviews />
       <Recommended />
       <Spotlight />
     </Column>

--- a/app/routes/products.$handle/sections/highlight-details.jsx
+++ b/app/routes/products.$handle/sections/highlight-details.jsx
@@ -13,15 +13,13 @@ import { Image } from '@shopify/hydrogen'
 export default function HighlightDetails() {
   const { details } = useLoaderData()
 
-  const features = details?.features
+  if (details?.features == null) return null
 
-  const highlights =
-    features != null
-      ? JSON.parse(features.reference.content.value)
-          .highlights
-      : null
+  const { highlights } = JSON.parse(
+    details.features.reference.content.value,
+  )
 
-  return highlights ? (
+  return (
     <Section className='items-center text-white py-44 bg-darkGray'>
       <Container resizeY='fill'>
         <Grid resizeY='fill'>
@@ -69,5 +67,5 @@ export default function HighlightDetails() {
         </div>
       </Background>
     </Section>
-  ) : null
+  )
 }

--- a/app/routes/products.$handle/sections/highlight-solution.jsx
+++ b/app/routes/products.$handle/sections/highlight-solution.jsx
@@ -19,7 +19,7 @@ import {
 export default function HighlightSolution() {
   const { solution, product } = useLoaderData()
 
-  const { featuredImage } = product
+  const { featuredImage } = data.product
   const title = solution?.reference?.title
   const description = solution?.reference.description
 

--- a/app/routes/products.$handle/sections/highlight-solution.jsx
+++ b/app/routes/products.$handle/sections/highlight-solution.jsx
@@ -17,13 +17,15 @@ import {
 } from '/app/components/hydrogen/new/Layout'
 
 export default function HighlightSolution() {
-  const { solution, product } = useLoaderData()
+  const data = useLoaderData()
+
+  if (data.solution == null) return null
 
   const { featuredImage } = data.product
-  const title = solution?.reference?.title
-  const description = solution?.reference.description
+  const { title, description, learn_more } =
+    data.solution.reference
 
-  return solution != null ? (
+  return (
     <Section className='aspect-[2/1]'>
       <Row
         className='relative z-10 h-full'
@@ -76,5 +78,5 @@ export default function HighlightSolution() {
         <span className='bg-white aspect-square w-14 -translate-y-7'></span>
       </div>
     </Section>
-  ) : null
+  )
 }

--- a/app/routes/products.$handle/sections/reviews.jsx
+++ b/app/routes/products.$handle/sections/reviews.jsx
@@ -14,10 +14,11 @@ import { useLoaderData } from '@remix-run/react'
 
 export default function Reviews() {
   const data = useLoaderData()
+
   const { review_count, review_avg, reviews } =
     data.reviews.reviews
 
-  const customerReviews = reviews?.references.nodes.map(
+  const customerReviews = reviews.references.nodes.map(
     (r, i) => {
       return {
         ...r,
@@ -27,13 +28,10 @@ export default function Reviews() {
     },
   )
 
-  const reviewAvg =
-    customerReviews != null
-      ? JSON.parse(review_avg.value).value
-      : null
-  const reviewCount = review_count?.value
+  const reviewAvg = JSON.parse(review_avg.value).value
+  const reviewCount = review_count.value
 
-  return customerReviews != null ? (
+  return (
     <Section>
       <Container paddingY='l' marginBottom>
         <Column gap={8}>
@@ -74,7 +72,7 @@ export default function Reviews() {
         </Row>
       </Container>
     </Section>
-  ) : null
+  )
 }
 
 const review = cva({

--- a/app/routes/products.$handle/sections/reviews.jsx
+++ b/app/routes/products.$handle/sections/reviews.jsx
@@ -18,6 +18,10 @@ export default function Reviews() {
   const { review_count, review_avg, reviews } =
     data.reviews.reviews
 
+  if (reviews == null) {
+    return null
+  }
+
   const customerReviews = reviews.references.nodes.map(
     (r, i) => {
       return {


### PR DESCRIPTION
Some products do not have all the possible data e.g. reviews, highlights, etc.
For these products the product page section components throw exceptions. To avoid this we need to null-check some parts of the loaded data .
Earlier I converted these checks to ternaries, because we had a bug in the navigator with early returns. However, those are fixed in https://github.com/concrete-utopia/utopia/pull/5904 , so I'm adding back the more readable and more navigator friendly (extra conditionals pollute the navigator too) early returns.