### PR TITLE
Replace fragment in Layout component with div.

### DIFF
--- a/app/components/Layout.jsx
+++ b/app/components/Layout.jsx
@@ -21,7 +21,7 @@ export function Layout({
   isLoggedIn,
 }) {
   return (
-    <>
+    <div>
       <CartAside cart={cart} />
       <SearchAside />
       <MobileMenuAside
@@ -46,7 +46,7 @@ export function Layout({
           )}
         </Await>
       </Suspense>
-    </>
+    </div>
   )
 }
 


### PR DESCRIPTION
**Problem:**
The unfocused and focused dimensions of the `Layout` component are different in the Utopia editor.

**Fix:**
This gets around the issue by replacing the fragment inside the `Layout` component with a div, as the fragment was causing the dimensions to be calculated from the metadata. But focusing the component results in additional metadata, which then gives the correct accumulated dimensions.