### PR TITLE
Remove Margins from the Review card

### DIFF
--- a/app/components/hydrogen/new/Layout.jsx
+++ b/app/components/hydrogen/new/Layout.jsx
@@ -278,10 +278,10 @@ export const Column = forwardRef(
         data-h2='Column'
         {...props}
         style={{
-          ...props.style,
           padding: padded ? 100 : undefined,
           maxWidth: maxWidth ?? props.style?.maxWidth,
           maxHeight: maxHeight ?? props.style?.maxHeight,
+          ...props.style,
         }}
       >
         {children}
@@ -325,10 +325,10 @@ export const Row = forwardRef(
         data-h2='Column'
         {...props}
         style={{
-          ...props.style,
           padding: padded ? 100 : undefined,
           maxWidth: maxWidth ?? props.style?.maxWidth,
           maxHeight: maxHeight ?? props.style?.maxHeight,
+          ...props.style,
         }}
       >
         {children}

--- a/app/routes/products.$handle/sections/reviews.jsx
+++ b/app/routes/products.$handle/sections/reviews.jsx
@@ -60,6 +60,7 @@ export default function Reviews() {
             align='end'
             maxHeight={1080}
             maxWidth={832}
+            style={{ gap: 48 }}
           >
             <Spacer height={144} />
             {customerReviews.map((review) => {
@@ -80,7 +81,7 @@ export default function Reviews() {
 }
 
 const review = cva({
-  base: ['mb-12'],
+  base: [],
   variants: {
     background: {
       black: 'bg-black text-white',
@@ -103,7 +104,7 @@ export function Review({ className, ...props }) {
     splitTextIntoSentences(quote)
 
   return (
-    <div className='relative inline-block mx-6'>
+    <div style={{ contain: 'layout' }}>
       <Column
         px={7}
         py={6}


### PR DESCRIPTION
the Reviews two column layout's spacing have been achieved by margins which we don't yet have a visual control for. Instead use, gap! we have a nice gap control!