### PR TITLE
mitigate blinking css due to utopia bug

### DIFF
--- a/utopia/storyboard.js
+++ b/utopia/storyboard.js
@@ -3,6 +3,11 @@ import { Storyboard, RemixScene } from 'utopia-api'
 
 import { getLoadContext } from '../server-context-getter'
 
+// this css is originally imported in root.jsx, but we have a bug which remounts the Remix scene and when that happens the css does not reload during interactions, leading to a white flash
+// by also importing it here, we prevent the blinking.
+// the real fix should be fixing the remount bug though
+import '../app/styles/app-generated.css'
+
 const contextGetter = getLoadContext(
   {
     PUBLIC_STORE_DOMAIN: '438c73-58.myshopify.com',


### PR DESCRIPTION
We have a bug in utopia which leads to the remix scene remounting during an interaction. After the remount happens, if we are in an active interaction session, only the interacted-with elements are allowed to re-render, which means we don't rerender the remix roots, which means this CSS has no chance to mount itself back to the canvas.

The mitigation is to _also_ import the css in storyboard.js which doesn't have the remount bug. This fully stops the blinking from happening. 

The remount is still happening and the utopia bug must be fixed, but in the interim, at least we can continue using the demo project.